### PR TITLE
Fixed generalized psolvers when being used on each iteration of the recursive algorithm

### DIFF
--- a/fatalattractors/psol_generalized.py
+++ b/fatalattractors/psol_generalized.py
@@ -217,9 +217,10 @@ def monotone_attractor_player1(g, node, function):
     return W, Wbis
 
 
-def psol_generalized(g, W1, W2):
+def psol_generalized(g, W1, W2, inverted=False):
     """
     Adaptation of psol partial solver to generalized parity games.
+    inverted true means we record odd priorities instead of even ones
     :param g: a game graph.
     :return: a partial solution g', W1', W2' in which g is an unsolved subgame of g and W1', W2' are included in the
     two respective winning regions of g.
@@ -236,7 +237,7 @@ def psol_generalized(g, W1, W2):
         for i in range(1, len(info)):
 
             # one of the priorities is odd
-            if info[i] % 2 == 1:
+            if info[i] % 2 == (not inverted):
 
                 found_odd = True
 
@@ -256,7 +257,7 @@ def psol_generalized(g, W1, W2):
 
                     W2.extend(att)
 
-                    return psol_generalized(g.subgame(complement), W1, W2)
+                    return psol_generalized(g.subgame(complement), W1, W2, inverted)
 
         # if we get here, then every priority is even or none of the computed attractors are fatal
 
@@ -275,6 +276,6 @@ def psol_generalized(g, W1, W2):
 
                 W1.extend(att)
 
-                return psol_generalized(g.subgame(complement), W1, W2)
+                return psol_generalized(g.subgame(complement), W1, W2, inverted)
 
     return g, W1, W2


### PR DESCRIPTION
An issue occurs with partial solvers when used multiple times during the recursive algorithm : the transformation of the game (+1 to each priority) was not being into account by partial solvers, thus the returned winning regions were not correct.

Here is a fix, which basically makes partial solvers work on "max odd" priorities instead of "max even" for player 0 in this case. It was already fixed this way for only one partial solver also used in [SPORE](https://github.com/Skar0/spore) (called GeneralizedBuchi in SPORE and psolB here).

Notice that there was no problem with "preprocessing algorithms", i.e. one call to the partial solver then call the recursive algorithm, nor with the classical recursive algorithm.